### PR TITLE
Allow negative Cohen's d input

### DIFF
--- a/app.py
+++ b/app.py
@@ -205,7 +205,7 @@ with col1:
 with col2:
     cohens_d_input = st.number_input(
         "Expected Cohen's d (Effect Size)", 
-        min_value=0.0, 
+        min_value=-5.0,  # Allow negative effect sizes
         value=st.session_state.current_d, 
         step=0.01, 
         format="%.2f",


### PR DESCRIPTION
## Summary
- permit negative effect sizes by allowing negative values for Cohen's d

## Testing
- `python -m py_compile $(git ls-files '*.py')`
